### PR TITLE
chore: Added docker-compose file to test the site without Ruby installed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem "jekyll", "~> 4.2"
+gem "jekyll", "~> 4.3.4"
 
 # group :jekyll_plugins do
 #   gem "jekyll-timeago", "~> 0.13.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,16 +3,16 @@ GEM
   specs:
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    bigdecimal (3.1.8)
+    bigdecimal (3.1.9)
     colorator (1.1.0)
     concurrent-ruby (1.3.4)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.2)
     forwardable-extended (2.6.0)
-    google-protobuf (4.29.1-arm64-darwin)
+    google-protobuf (4.30.2)
       bigdecimal
       rake (>= 13)
     http_parser.rb (0.8.0)
@@ -57,8 +57,9 @@ GEM
     rexml (3.3.9)
     rouge (4.5.1)
     safe_yaml (1.0.5)
-    sass-embedded (1.82.0-arm64-darwin)
-      google-protobuf (~> 4.28)
+    sass-embedded (1.86.3)
+      google-protobuf (~> 4.30)
+      rake (>= 13)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.6.0)
@@ -68,7 +69,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  jekyll (~> 4.2)
+  jekyll (~> 4.3.4)
 
 BUNDLED WITH
    2.5.23

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  jekyll:
+    image: bretfisher/jekyll-serve
+    volumes:
+      - .:/site
+    ports:
+      - '4000:4000'

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,15 @@ Visit under [operaton.org](https://operaton.org)
 
 ## Getting Started
 
+You can either install Ruby and use jekyll directly or docker-compose
+
+### jekyll serve
+
 - Make sure Jekyll is available on your machine: [Official installation guide](https://jekyllrb.com/docs/installation/)
+- (optional) Run `bundle install` in the projects root to update the dependencies if needed
 - Run `jekyll serve` in the projects root folder
 - Visit `localhost:4000`
+
+### docker-compose
+
+- Run `docker-compose up -d` in the root of this project


### PR DESCRIPTION
I had some issues with Ruby / ARM Chips on my Mac and was unable to get Jekyll to run locally, so I added a docker-compose file which lets you build and serve the application in Docker without the need to install everything on your machine

`docker compose up` is enough, app starts on :4000 then