### PR TITLE
Update slack link

### DIFF
--- a/.devenv/scripts/maintenance/update-slack-link.sh
+++ b/.devenv/scripts/maintenance/update-slack-link.sh
@@ -27,7 +27,7 @@ AFFECTED_FILES=(index.html chat.md)
 
 for AFFECTED_FILE in "${AFFECTED_FILES[@]}"; do
   echo "🔄 Updating Slack Invitation URL in $AFFECTED_FILE"
-  sed_inplace "s|${EXPECTED_PREFIX}[a-zA-Z0-9\-]+|${SLACK_INVITATION_URL}|" $AFFECTED_FILE
+  sed_inplace "s|${EXPECTED_PREFIX}[^\)^\"]+|${SLACK_INVITATION_URL}|" $AFFECTED_FILE
 done
 
 echo "✅  Done!"

--- a/chat.md
+++ b/chat.md
@@ -7,4 +7,4 @@ title: "Chat (Slack)"
 
 We are currently using Slack alongside the Forum for faster communication.
 
-Feel free to join the conversation by using [Slack's invitation link](https://join.slack.com/t/operaton/shared_invite/zt-2yubtdpwm-GvmBCzyx1OVihW3v2NnCvw).
+Feel free to join the conversation by using [Slack's invitation link](https://join.slack.com/t/operaton/shared_invite/zt-352patys4-eXeuc1tpB041gPGA820~hA).

--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@ description: "Operaton is a community-driven free open-source BPMN engine. It in
         <li>
           An inclusive and welcoming community
           (join the <a href="https://forum.operaton.org/">Forum</a>
-          and <a href="https://join.slack.com/t/operaton/shared_invite/zt-2yubtdpwm-GvmBCzyx1OVihW3v2NnCvw">Chat (Slack)</a>)
+          and <a href="https://join.slack.com/t/operaton/shared_invite/zt-352patys4-eXeuc1tpB041gPGA820~hA">Chat (Slack)</a>)
         </li>
         <li>
           Contributions <a href="https://github.com/operaton/operaton/blob/main/CONTRIBUTING.md">are welcome</a>
@@ -207,7 +207,7 @@ description: "Operaton is a community-driven free open-source BPMN engine. It in
 
       <p>
       If you have any further questions, feel free to ask in our <a href="https://forum.operaton.org/">Forum</a>
-        or on our <a href="https://join.slack.com/t/operaton/shared_invite/zt-2v6umjt92-d2DRmsoR1fqDEVlJB5IkNA">Slack Channel</a>.
+        or on our <a href="https://join.slack.com/t/operaton/shared_invite/zt-352patys4-eXeuc1tpB041gPGA820~hA">Slack Channel</a>.
       </p>
 
     </details>
@@ -219,7 +219,7 @@ description: "Operaton is a community-driven free open-source BPMN engine. It in
 
       <ul>
         <li><a href="https://forum.operaton.org/">Forum</a></li>
-        <li><a href="https://join.slack.com/t/operaton/shared_invite/zt-2yubtdpwm-GvmBCzyx1OVihW3v2NnCvw">Chat (Slack)</a></li>
+        <li><a href="https://join.slack.com/t/operaton/shared_invite/zt-352patys4-eXeuc1tpB041gPGA820~hA">Chat (Slack)</a></li>
         <li><a href="https://fosstodon.org/@operaton">Mastodon</a></li>
         <li><a href="https://www.linkedin.com/company/operaton">LinkedIn</a></li>
         <li>mail [at] operaton.org </li>


### PR DESCRIPTION
This change fixes the replacement pattern for slack invitations. Those URLs may contain `~` characters that have not been covered before.

Also update the invitation link to latest.