### PR TITLE
Update Roadmap

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,12 +109,17 @@ main-class: start-page
     <div class="group">
       <h3>November 2025</h3>
       <div class="task">Release 1.0</div>
-      <div class="task">New Web Apps Beta</div>
+      <div class="task">Website Relaunch</div>
     </div>
     <div class="arrow"></div>
     <div class="group">
-      <h3>2026 and beyond</h3>
-      <div class="task">Release 2.0</div>
+      <h3>February 2026</h3>
+      <div class="task">Release 1.1</div>
+    </div>
+    <div class="arrow"></div>
+    <div class="group">
+      <h3>2026</h3>
+      <div class="task">Release 1.2</div>
     </div>
     <div class="arrow"></div>
     <div class="end"></div>

--- a/roadmap.md
+++ b/roadmap.md
@@ -21,18 +21,44 @@ title: "Roadmap"
   <div class="group">
     <h3>November 2025</h3>
     <div class="task">Release 1.0</div>
-    <div class="task">New Web Apps Beta</div>
+    <div class="task">Website Relaunch</div>
   </div>
   <div class="arrow"></div>
   <div class="group">
-    <h3>2026 and beyond</h3>
-    <div class="task">Release 2.0</div>
+    <h3>February 2026</h3>
+    <div class="task">Release 1.1</div>
+  </div>
+  <div class="arrow"></div>
+  <div class="group">
+    <h3>2026</h3>
+    <div class="task">Release 1.2</div>
   </div>
   <div class="arrow"></div>
   <div class="end"></div>
 </div>
 
 <br>
+
+### 2026 and beyond
+
+- Make new Web applications production ready and replace legacy ones
+- Further improvements based on our users needs
+- Remove deprecated code
+- Establish feature releases with plannable release cadence
+- SpringBoot 4/Spring 7 support
+- Job executor performance improvements
+- Jakarta EE 11 support
+- JUnit 6 support
+
+### February 2026
+
+#### Release 1.1
+
+- Update all dependencies to latest versions
+- Fixes for low prio issues reported by the community
+- Wildfly 38+ support
+
+## Past Changes
 
 ### November 2025
 
@@ -41,16 +67,15 @@ title: "Roadmap"
 - End of life Camunda 7.24 CE
 - Release 1.0 based on 7.24 CE
 
-### 2026 and beyond
+#### Operaton Hub launched
 
-- Release version 1.1 – No breaking changes
-- Further improvements based on our users needs
-- Remove deprecated code
-- Release 2.0
+- New community platform for sharing Operaton solutions
 
-## Past Changes
+### October 2025
 
-### 2025
+- operaton.org website relaunch
+
+### Mid 2025
 
 - Publish revised documentation
 - Drop dependency on legacy technology like Wildfly 26, JavaEE and Spring 5


### PR DESCRIPTION
This PR updates the roadmap.

Main point is changing from announced version 2.0 to 1.1 and 1.2 and some content about them.
Items discussed on Slack.