### PR TITLE
fix(website): Correct Slack URL and update maintenance script

### DIFF
--- a/.devenv/scripts/maintenance/update-slack-link.sh
+++ b/.devenv/scripts/maintenance/update-slack-link.sh
@@ -23,11 +23,15 @@ sed_inplace() {
 pushd $(pwd) > /dev/null
 cd $(git rev-parse --show-toplevel) || exit 1
 
-AFFECTED_FILES=(index.html chat.md faq.md)
+AFFECTED_FILES=(index.html chat.md faq.md _data/resources.yml)
 
 for AFFECTED_FILE in "${AFFECTED_FILES[@]}"; do
   echo "🔄 Updating Slack Invitation URL in $AFFECTED_FILE"
-  sed_inplace "s|${EXPECTED_PREFIX}[^\)^\"]+|${SLACK_INVITATION_URL}|" $AFFECTED_FILE
+  if [[ "$AFFECTED_FILE" == "_data/resources.yml" ]]; then
+    sed_inplace "s|url: ${EXPECTED_PREFIX}[^ ]*|url: ${SLACK_INVITATION_URL}|" $AFFECTED_FILE
+  else
+    sed_inplace "s|${EXPECTED_PREFIX}[^\)^\"]+|${SLACK_INVITATION_URL}|" $AFFECTED_FILE
+  fi
 done
 
 echo "✅  Done!"

--- a/_data/resources.yml
+++ b/_data/resources.yml
@@ -36,7 +36,7 @@ Community:
     tag: Discussion, Help
     resources:
       - name: Slack
-        url:
+        url: https://join.slack.com/t/operaton/shared_invite/zt-3id7iv5lz-zT7uGVWLCVNG_zpnAGpq9g
 Public Channels:
   LinkedIn:
     tag: Updates


### PR DESCRIPTION
This PR fixes the broken Slack link on the `/resources` page.
- Fixes:#50

Let me know if any changes are needed.