### PR TITLE
feat(hub): add bpmn-to-code to operaton hub (#87)

### DIFF
--- a/_data/hub-items.yml
+++ b/_data/hub-items.yml
@@ -100,7 +100,7 @@
   description: >-
     A tool designed to simplify process automation through automated code generation from BPMN models. Its vision is to foster clean & robust solutions for BPMN-based process automation. It aims to provide a range of features — such as generating API definition files from BPMN process models — to reduce manual effort, simplify testing, promote the creation of clean process models, and ensure consistency between your BPMN model and your code.
   type: 3
-  license: 0
+  license: 7
   links:
     - label: Website
       url: https://bpmn-to-code.miragon.io/


### PR DESCRIPTION
linked the wrong licence in the previous PR. 
sorry for the inconvenience :)

should now reflect the MIT-license from the project 
https://github.com/emaarco/bpmn-to-code

fixes #86 