### PR TITLE
docs(blog): announce 2.1.3 & 1.1.5 (1.1.x EOL)

### DIFF
--- a/_posts/2026-07-24-operaton-2-1-3-and-1-1-5-released.md
+++ b/_posts/2026-07-24-operaton-2-1-3-and-1-1-5-released.md
@@ -1,0 +1,36 @@
+---
+layout: post
+author: The Operaton Team
+---
+
+## Operaton 2.1.3 and 1.1.5 Released — Security Fixes, and 1.1.x Reaches End of Life
+
+We've published two maintenance releases today: **Operaton 2.1.3** and **Operaton 1.1.5**.
+
+### Operaton 2.1.3 — security fixes
+
+2.1.3 pins two vulnerable transitive dependencies that reached Operaton through
+Spring Boot 4 and the Quarkus extension:
+
+- **Netty** → `4.2.16.Final` (fixes CVE-2026-56745 and related advisories)
+- **Jackson** → `3.1.5` (fixes CVE-2026-59889)
+
+There are **no database schema changes** and no REST API changes, so upgrading
+from 2.1.x is a drop-in replacement. We recommend all 2.1.x users update.
+
+Release notes: <https://docs.operaton.org/docs/documentation/reference/release-notes/2_1/>
+
+### Operaton 1.1.5 — final 1.1.x release (End of Life)
+
+1.1.5 is a maintenance release with dependency updates, and it is the **last
+release of the 1.1.x line** — 1.1.x is now **end of life** and will receive no
+further updates, including security fixes. Users still on 1.1.x should plan to
+move to **2.1.x**, which is fully maintained.
+
+Release notes: <https://docs.operaton.org/docs/documentation/reference/release-notes/1_1/>
+
+### Coming next: 2.2.0-M2 preview
+
+A **2.2.0-M2** milestone build is available for early testing of the upcoming
+2.2 line. It's a preview — **not intended for production**.
+Prerelease: <https://github.com/operaton/operaton/releases/tag/v2.2.0-M2>

--- a/_posts/2026-07-24-operaton-2-1-3-and-1-1-5-released.md
+++ b/_posts/2026-07-24-operaton-2-1-3-and-1-1-5-released.md
@@ -3,11 +3,11 @@ layout: post
 author: The Operaton Team
 ---
 
-## Operaton 2.1.3 and 1.1.5 Released — Security Fixes, and 1.1.x Reaches End of Life
+## Operaton 2.1.3 and 1.1.5 Released — Dependency Security Updates, and 1.1.x Reaches End of Life
 
 We've published two maintenance releases today: **Operaton 2.1.3** and **Operaton 1.1.5**.
 
-### Operaton 2.1.3 — security fixes
+### Operaton 2.1.3 — security updates in dependencies
 
 2.1.3 pins two vulnerable transitive dependencies that reached Operaton through
 Spring Boot 4 and the Quarkus extension:

--- a/index.html
+++ b/index.html
@@ -40,13 +40,13 @@ main-class: start-page
       <header>
         <p>#changelog</p>
         <h3>
-          <a href="https://github.com/operaton/operaton/releases/tag/v2.1.2">
-            Version 2.1.2
+          <a href="https://github.com/operaton/operaton/releases/tag/v2.1.3">
+            Version 2.1.3
           </a>
         </h3>
       </header>
       <p>
-        Patch release with security updates and bug fixes
+        Security fixes for bundled Netty and Jackson dependencies.
       </p>
     </div>
     <div class="card">

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@ main-class: start-page
         </h3>
       </header>
       <p>
-        Security fixes for bundled Netty and Jackson dependencies.
+        Security updates in bundled dependencies (Netty and Jackson).
       </p>
     </div>
     <div class="card">


### PR DESCRIPTION
Release announcement for **2.1.3** and **1.1.5** (published 2026-07-24).

## Changes
- **`index.html` `#changelog` card** → Version 2.1.3, summary "Security fixes for bundled Netty and Jackson dependencies." (highest version released today; M2 is a preview, covered in the post prose.)
- **Blog post** `_posts/2026-07-24-operaton-2-1-3-and-1-1-5-released.md`:
  - **2.1.3** — Netty 4.2.16.Final + Jackson 3.1.5 security fixes (CVE-2026-56745, CVE-2026-59889); drop-in upgrade.
  - **1.1.5** — final 1.1.x release; **1.1.x is now End of Life**; migrate to 2.1.x.
  - **2.2.0-M2** — preview build mention (not for production).

Draft — please review the prose before merging.
